### PR TITLE
Add PR automatic build and preview deploy

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -1,0 +1,44 @@
+# this file handles all the messy business of auto-building the game when changes are pushed and publishing the latest build to itch.io, where it can be enjoyed publicly.
+# please do not modify this file unless you have very good reason to do so, as it will likely break the game for everyone else.
+
+name: Test and Deploy PRs
+
+on:
+  pull_request:
+    paths: 
+      - 'scenes/**'
+      - 'scripts/**'
+      - 'sfx/**'
+      - 'sprites/**'
+      - export_presets.cfg
+      - .project.godot
+
+jobs:
+  build_game:
+    runs-on: ubuntu-latest
+    name: Build Game
+    steps:
+      - name: checkout latest code
+        uses: actions/checkout@v2.3.1
+        with:
+          fetch-depth: 0
+      - name: export with Godot Engine and release on GitHub
+        uses: firebelley/godot-export@v3.0.0
+        with:
+          create_release: false
+          godot_executable_download_url: https://downloads.tuxfamily.org/godotengine/3.4.4/Godot_v3.4.4-stable_linux_headless.64.zip
+          godot_export_templates_download_url: https://downloads.tuxfamily.org/godotengine/3.4.4/Godot_v3.4.4-stable_export_templates.tpz
+          relative_export_path: ./
+          relative_project_path: ./
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Deploy preview to Netlify
+        uses: nwtgck/actions-netlify@v1.2
+        with:
+          publish-dir: './HTML5'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "Deploy from GitHub Actions"
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}


### PR DESCRIPTION
This adds a new GitHub Actions workflow! Every time somebody opens or edits a PR that changes game assets (see lines 9-14 for the list of paths we count as "game assets"), this does 2 things:

1. Build the game, throwing up a big red 'x' if it fails to build. In the link below, the "All checks have passed" green checkmark means it built successfully; it would be red otherwise.
2. Deploy a preview copy of the game (with the new changes) to the web (via Netlify) and add a comment to the PR linking to that playable build
 
https://github.com/lazerwalker/a-little-game-called-mario/pull/2 is a messy example of this working -- you can see a number of succeeding and failing builds there, plus the link to a playable version.

Merging this in requires having a Netlify account with a personal access token (and site ID) added as repository secrets. Our usage will be well within the free tier; this won't cost any money. I'm happy to walk you through creating an account and dropping in your own creds, or I'm also happy to just drop in the same keys I'm using in my fork. LMK!