### PR TITLE
Add jump input buffering

### DIFF
--- a/scripts/Player.gd
+++ b/scripts/Player.gd
@@ -9,8 +9,10 @@ const MAXSPEED = 300
 const JUMPFORCE = 1100
 const ACCEL = 50
 const COYOTE_TIME = 0.1
+const JUMP_BUFFER_TIME = 0.05
 
 var coyote_timer = COYOTE_TIME # used to give a bit of extra-time to jump after leaving the ground
+var jump_buffer_timer = 0 # gives a bit of buffer to hit the jump button before landing
 var motion = Vector2()
 var gravity_multiplier = 1 # used for jump height variability
 
@@ -43,18 +45,19 @@ func _physics_process(delta : float) -> void:
 		sprite.play("idle")
 		motion.x = lerp(motion.x, 0, 0.2)
 
-	if coyote_timer > 0 and Input.is_action_just_pressed("jump"):
-		squash();
-		yield(tween, "tween_all_completed")
-		stretch();
-		coyote_timer = 0
-		motion.y = -JUMPFORCE
-		$JumpSFX.play()
-		emit_signal("jumping")
+	jump_buffer_timer -= delta
+	if Input.is_action_just_pressed("jump"):
+		if coyote_timer > 0:
+			jump()
+		else:
+			jump_buffer_timer = JUMP_BUFFER_TIME
 
 	if is_on_floor():
 		coyote_timer = COYOTE_TIME
 		gravity_multiplier = 1
+		# the player pressed jump right before landing
+		if jump_buffer_timer > 0:
+			jump()
 	else:
 		coyote_timer -= delta
 		# while we're holding the jump button we should jump higher
@@ -65,6 +68,16 @@ func _physics_process(delta : float) -> void:
 		sprite.play("jump")
 
 	motion = move_and_slide(motion, UP)
+
+func jump():
+	jump_buffer_timer = 0
+	squash();
+	yield(tween, "tween_all_completed")
+	stretch();
+	coyote_timer = 0
+	motion.y = -JUMPFORCE
+	$JumpSFX.play()
+	emit_signal("jumping")
 	
 func squash(time=0.1, returnDelay=0):
 	tween.interpolate_property(sprite, "scale", original_scale, squash_scale, time, Tween.TRANS_BACK, Tween.EASE_OUT)


### PR DESCRIPTION
If the player hits the jump button right before landing, there's a small window of time where the jump will still register.
The value may need tweaking but I think jumping around feels better now.