### PR TITLE
Add slipping past walls when jumping, #35

### DIFF
--- a/scripts/Player.gd
+++ b/scripts/Player.gd
@@ -10,6 +10,7 @@ const JUMPFORCE = 1100
 const ACCEL = 50
 const COYOTE_TIME = 0.1
 const JUMP_BUFFER_TIME = 0.05
+const JUMP_SLIP_RANGE = 16
 
 var coyote_timer = COYOTE_TIME # used to give a bit of extra-time to jump after leaving the ground
 var jump_buffer_timer = 0 # gives a bit of buffer to hit the jump button before landing
@@ -79,7 +80,28 @@ func _physics_process(delta : float) -> void:
 		crouching = false
 		unsquash()
 
-	motion = move_and_slide(motion, UP)
+	var move_and_slide_result = move_and_slide(motion, UP)
+	var slide_count = get_slide_count()
+	# check for an upwards-collision
+	if slide_count && get_slide_collision(slide_count-1).get_angle(Vector2(0,1)) == 0:
+		var slipped = try_jump_slip() # try to adjust player position to "slip" past a wall
+		if !slipped:
+			motion = move_and_slide_result # apply original result if no valid slip found
+	else:
+		motion = move_and_slide_result
+
+func try_jump_slip():
+	var original_x = position.x # remember original x position
+	# check collisions in nearby x positions within JUMP_SLIP_RANGE
+	for x in range(1, JUMP_SLIP_RANGE):
+		for p in [-1, 1]:
+			position.x = original_x + x * p
+			move_and_slide(motion, UP)
+			if(get_slide_count() == 0):
+				return true # if no collision, return success
+	# restore original x position if couldn't find a slip
+	position.x = original_x
+	return false
 
 func crouch():
 	crouching = true


### PR DESCRIPTION
To address issue #35, this change allows the play to "slip past" the edges of walls when jumping.

When an upwards collision is detected, the player is moved in positive and negative X positions within the range of `JUMP_SLIP_RANGE` to see if a collision can be avoided. If a free space is found, the player's new X position is committed and they continue their motion upward. Otherwise, the original collision motion is applied to the player.

_Please note this is my first time touching Godot. The project sounded so fun that I had to get involved!_