### PR TITLE
Add 'ui' folder to PR build criteria

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -13,6 +13,7 @@ on:
       - 'scripts/**'
       - 'sfx/**'
       - 'sprites/**'
+      - 'ui/**'
       - export_presets.cfg
       - .project.godot
 


### PR DESCRIPTION
14 hours ago, someone created a new 'ui' folder and started putting files there. That broke our PR build script. 

See https://github.com/iznaut/a-little-game-called-mario/discussions/50 for structural fixes to avoid doing this any time anyone creates a new dir.