### PR TITLE
Show a warning popup when opening the project in older versions of Godot

### DIFF
--- a/addons/version_checker/plugin.cfg
+++ b/addons/version_checker/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="Version Checker"
+description=""
+author="Paul Joannon"
+version=""
+script="plugin.gd"

--- a/addons/version_checker/plugin.gd
+++ b/addons/version_checker/plugin.gd
@@ -1,0 +1,21 @@
+tool
+extends EditorPlugin
+
+var popup_scene : PackedScene = preload("res://addons/version_checker/version_checker_popup.tscn")
+
+
+func _enter_tree() -> void:
+	var version_info : Dictionary = Engine.get_version_info()
+
+	if version_info.major == 3 and version_info.minor >= 4:
+		return
+
+	var popup : AcceptDialog = popup_scene.instance()
+	popup.connect("confirmed", popup, "hide")
+	popup.connect("popup_hide", popup, "queue_free")
+
+	popup.dialog_text = popup.dialog_text.replace("XXX", version_info.string)
+
+	get_editor_interface().get_base_control().add_child(popup)
+
+	popup.popup_centered_clamped(Vector2(340, 180))

--- a/addons/version_checker/version_checker_popup.tscn
+++ b/addons/version_checker/version_checker_popup.tscn
@@ -1,0 +1,16 @@
+[gd_scene format=2]
+
+[node name="Control" type="AcceptDialog"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_right = -684.0
+margin_bottom = -420.0
+popup_exclusive = true
+window_title = "Version error"
+dialog_text = "This project is not compatible with the version of Godot you are using (XXX).
+
+Please use Godot 3.4 to edit this project."
+dialog_autowrap = true
+__meta__ = {
+"_edit_use_anchors_": false
+}

--- a/project.godot
+++ b/project.godot
@@ -68,6 +68,10 @@ gdscript/warnings/return_value_discarded=false
 window/stretch/mode="2d"
 window/stretch/aspect="keep"
 
+[editor_plugins]
+
+enabled=PoolStringArray( "res://addons/version_checker/plugin.cfg" )
+
 [importer_defaults]
 
 texture={


### PR DESCRIPTION
![godot_7uupLfLjEb](https://user-images.githubusercontent.com/437025/162587992-8e90570b-e315-4220-9713-cbae709a0a8a.png)

This should prevent most people from committing weird changes from outdated Godot versions.